### PR TITLE
bugfix: performance fix for get_description

### DIFF
--- a/classes/condition.php
+++ b/classes/condition.php
@@ -169,15 +169,14 @@ class condition extends \core_availability\condition {
      *   this item
      */
     public function get_description($full, $not, \core_availability\info $info) {
-      global $DB;
-        // Get name for module.
-        $modc = get_courses();
+        global $DB;
 
-        $modname = get_string('missing', 'availability_othercompleted');
-        foreach ($modc as $modcs) {
-            if($modcs->id == $this->cmid){
-                $modname = $modcs->fullname;
-            }
+        // Find the course, and allow missing.
+        $coursename = $DB->get_field('course', 'fullname', ['id' => $this->cmid]);
+
+        // Course might have been deleted - let the user know its missing.
+        if (empty($coursename)) {
+            $coursename = get_string('missing', 'availability_othercompleted');
         }
 
         // Work out which lang string to use.
@@ -199,7 +198,7 @@ class condition extends \core_availability\condition {
             $str = 'requires_' . self::get_lang_string_keyword($this->expectedcompletion);
         }
 
-        return get_string($str, 'availability_othercompleted', $modname);
+        return get_string($str, 'availability_othercompleted', $coursename);
     }
 
     protected function get_debug_string() {

--- a/lang/en/availability_othercompleted.php
+++ b/lang/en/availability_othercompleted.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$string['description'] = 'Require students to complete other course .';
+$string['description'] = 'Require students to complete other course.';
 $string['error_selectcmid'] = 'You must select an course for the completion condition.';
 $string['label_cm'] = 'Activity or resource';
 $string['label_completion'] = 'Required completion status';
-$string['missing'] = '(Missing activity)';
+$string['missing'] = '(Missing course)';
 $string['option_complete'] = 'must be marked complete';
 $string['option_incomplete'] = 'must not be marked complete';
 $string['pluginname'] = 'Restriction by other course completion';

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021112501;
+$plugin->version = 2021112502;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 2021033000;
 $plugin->requires = 2019051100;


### PR DESCRIPTION
This fixes a massive performance issue with get_description. Previously would query all courses from the database, and iterates them one by one in php to find the matching course name. This is just plain silly, it should just filter this on the DB.

For example, on a site with 20k courses - this takes 5 seconds.

![image](https://github.com/catalyst/moodle-availability_othercompleted/assets/17095477/38eafab6-1dab-400d-aeef-01ce1012181f)

Also I have tweaked the lang strings since they still reference course modules (since this condition was more or less duplicated from the availability_completion code without changing these strings)

Now if a course is missing it shows `missing course` instead of `missing course module`:

![Screenshot](https://github.com/catalyst/moodle-availability_othercompleted/assets/17095477/afc18fd2-1ae8-4245-b31f-b9128ff96964)

