### PR TITLE
Bugfix: Retain course condition after category clone

### DIFF
--- a/classes/condition.php
+++ b/classes/condition.php
@@ -215,23 +215,22 @@ class condition extends \core_availability\condition {
         return 'cm' . $this->cmid . ' ' . $type;
     }
 
-    public function update_after_restore($restoreid, $courseid, base_logger $logger, $name) {
+    /**
+     * Include this condition only if course still exists. 
+     *
+     * @param int $restoreid The restore Id.
+     * @param int $courseid The ID of the course.
+     * @param base_logger $logger The logger being used.
+     * @param string $name Name of item being restored.
+     * @param base_task $task The task being performed.
+     *
+     * @return bool
+     */
+    public function include_after_restore($restoreid, $courseid, \base_logger $logger, $name, \base_task $task) {
         global $DB;
-        $rec = restore_dbops::get_backup_ids_record($restoreid, 'course_module', $this->cmid);
-        if (!$rec || !$rec->newitemid) {
-            // If we are on the same course (e.g. duplicate) then we can just
-            // use the existing one.
-            if ($DB->record_exists('course_modules',
-                                   ['id' => $this->cmid, 'course' => $courseid])) {
-                return false;
-            }
-            // Otherwise it's a warning.
-            $this->cmid = 0;
-            $logger->process('Restored item (' . $name .
-                             ') has availability condition on module that was not restored',
-                             backup::LOG_WARNING);
-        } else {
-            $this->cmid = (int)$rec->newitemid;
+
+        if (!$DB->record_exists('course', ['id' => $this->cmid])) {
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
**Description:** Currently, when using `tool_clonecategory`, `othercompleted` availability conditions are set to null for sections/modules that were cloned. 

This PR removes the `update_after_restore` function. For this availability condition, this function is not needed. This seems to have been copied (almost directly from [availability_completion](https://github.com/moodle/moodle/blob/MOODLE_401_STABLE/availability/condition/completion/classes/condition.php#L432)) from other conditions that rely on in-course resources - e.g. `availability_condition` sets restrictions based on if a course module within the same course has been completed. During a clone/restore, references to course modules would need to be updated. Other availability plugins such as `profile` do not implement this function.

Furthermore, the function incorrectly checks `coursemodules` table and uses `$this->cmid` (where for this plugin, `cmid = courseid`. 

```php
public function update_after_restore($restoreid, $courseid, base_logger $logger, $name) {
    global $DB;
    $rec = restore_dbops::get_backup_ids_record($restoreid, 'course_module', $this->cmid);
    if (!$rec || !$rec->newitemid) {
        // If we are on the same course (e.g. duplicate) then we can just
        // use the existing one.
        if ($DB->record_exists('coursemodules',
                               ['id' => $this->cmid, 'course' => $courseid])) {
            return false;
        }
        // Otherwise it's a warning.
        $this->cmid = 0;
        $logger->process('Restored item (' . $name .
                         ') has availability condition on module that was not restored',
                         backup::LOG_WARNING);
    } else {
        $this->cmid = (int)$rec->newitemid;
    }
    return true;
}
```

A new `include_after_restore` performs a check to see if this availability plugin should still be kept after restore. See the [upgrade.txt](https://github.com/moodle/moodle/blob/MOODLE_401_STABLE/availability/upgrade.txt#L21) for why it was introduced into Moodle and [here](https://github.com/moodle/moodle/blob/MOODLE_401_STABLE/availability/condition/grouping/classes/condition.php#L172) for an implementation.

